### PR TITLE
添加Github Actions作为CI支持

### DIFF
--- a/.github/workflows/DDTVLiveRec.yml
+++ b/.github/workflows/DDTVLiveRec.yml
@@ -21,6 +21,6 @@ jobs:
       with:
         dotnet-version: '5.0.x'
     - name: Restore dependencies
-      run: dotnet restore
+      run: cd DDTVLiveRec && dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: cd DDTVLiveRec && dotnet build --no-restore

--- a/.github/workflows/DDTVLiveRec.yml
+++ b/.github/workflows/DDTVLiveRec.yml
@@ -1,0 +1,26 @@
+name: DDTVLiveRec
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore

--- a/.github/workflows/DDTVLiveRec.yml
+++ b/.github/workflows/DDTVLiveRec.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0
+        dotnet-version: '5.0.x'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/DDTV_New.yml
+++ b/.github/workflows/DDTV_New.yml
@@ -66,10 +66,10 @@ jobs:
 
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1
 
     - name: Setup NuGet
-      uses: nuget/setup-nuget@v1.0.5
+      uses: nuget/setup-nuget@v1
 
     - name: Restore NuGet Packages
       run: nuget restore $env:Solution_Name

--- a/.github/workflows/DDTV_New.yml
+++ b/.github/workflows/DDTV_New.yml
@@ -1,0 +1,80 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will build, test, sign and package a WPF or Windows Forms desktop application
+# built on .NET Core.
+# To learn how to migrate your existing application to .NET Core,
+# refer to https://docs.microsoft.com/en-us/dotnet/desktop-wpf/migration/convert-project-from-net-framework
+#
+# To configure this workflow:
+#
+# 1. Configure environment variables
+# GitHub sets default environment variables for every workflow run.
+# Replace the variables relative to your project in the "env" section below.
+#
+# 2. Signing
+# Generate a signing certificate in the Windows Application
+# Packaging Project or add an existing signing certificate to the project.
+# Next, use PowerShell to encode the .pfx file using Base64 encoding
+# by running the following Powershell script to generate the output string:
+#
+# $pfx_cert = Get-Content '.\SigningCertificate.pfx' -Encoding Byte
+# [System.Convert]::ToBase64String($pfx_cert) | Out-File 'SigningCertificate_Encoded.txt'
+#
+# Open the output file, SigningCertificate_Encoded.txt, and copy the
+# string inside. Then, add the string to the repo as a GitHub secret
+# and name it "Base64_Encoded_Pfx."
+# For more information on how to configure your signing certificate for
+# this workflow, refer to https://github.com/microsoft/github-actions-for-desktop-apps#signing
+#
+# Finally, add the signing certificate password to the repo as a secret and name it "Pfx_Key".
+# See "Build the Windows Application Packaging project" below to see how the secret is used.
+#
+# For more information on GitHub Actions, refer to https://github.com/features/actions
+# For a complete CI/CD sample to get started with GitHub Action workflows for Desktop Applications,
+# refer to https://github.com/microsoft/github-actions-for-desktop-apps
+
+name: DDTV_New
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    runs-on: windows-latest  # For a list of available runner types, refer to
+                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+
+    env:
+      Solution_Name: DDTV_New.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Setup NuGet
+      uses: NuGet/setup-nuget@v1.0.2
+
+    - name: Restore NuGet Packages
+      run: nuget restore $env:Solution_Name
+
+    - name: Build App
+      run: cd DDTV_New && msbuild /property:Configuration=$env:Configuration /p:DebugType=None
+      env:
+        Configuration: ${{ matrix.configuration }}

--- a/.github/workflows/DDTV_New.yml
+++ b/.github/workflows/DDTV_New.yml
@@ -69,7 +69,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@v1.0.2
+      uses: NuGet/setup-nuget@latest
 
     - name: Restore NuGet Packages
       run: nuget restore $env:Solution_Name

--- a/.github/workflows/DDTV_New.yml
+++ b/.github/workflows/DDTV_New.yml
@@ -69,7 +69,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Setup NuGet
-      uses: NuGet/setup-nuget@latest
+      uses: nuget/setup-nuget@v1.0.5
 
     - name: Restore NuGet Packages
       run: nuget restore $env:Solution_Name


### PR DESCRIPTION
鉴于当前代码不止提供Windows单平台的构建支持，使用自动化的CI系统能够简化代码构建的验证工作。

该PR使用GitHub Actions支持在push到master和提交PR的时候确保：

1. DDTV_New在Windows下能够成功编译
2. DDTVLiveRec在Windows/Linux/MacOS下能够成功编译

以防止错误提交/merge了无法正常编译的代码。