### PR TITLE
修复重连时弹幕流和礼物流断开的问题

### DIFF
--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -526,7 +526,6 @@ namespace Auxiliary
                         {
                             DownIofo.网络超时 = true;
                             DownIofo.备注 = "下载流中断，检测到房间仍为开播状态，新建续下任务。";
-                            DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
                             switch (DownIofo.平台)
                             {
                                 case "bilibili":
@@ -546,7 +545,7 @@ namespace Auxiliary
                                             //    DownIofo.文件保存路径 = DownIofo.继承.合并后的文件路径;
                                             //}
                                         }
-                                        DownIofo.下载状态 = false;
+                                        下载结束提醒(false, "下载任务结束", DownIofo);
                                         Downloader 重连下载对象 = Downloader.新建下载对象(
                                             DownIofo.平台,
                                             DownIofo.房间_频道号,
@@ -560,14 +559,14 @@ namespace Auxiliary
                                             DownIofo.文件保存路径,
                                             DownIofo
                                             );
+                                        重连下载对象.DownIofo.弹幕录制基准时间 = DownIofo.弹幕录制基准时间;
+                                        重连下载对象.DownIofo.阿B直播流对象 = DownIofo.阿B直播流对象;
+                                        重连下载对象.DownIofo.弹幕储存流 = DownIofo.弹幕储存流;
+                                        重连下载对象.DownIofo.礼物储存流 = DownIofo.礼物储存流;
                                         if (!重连下载对象.DownIofo.下载状态)
                                         {
                                             try
                                             {
-                                                重连下载对象.DownIofo.弹幕录制基准时间 = DownIofo.弹幕录制基准时间;
-                                                重连下载对象.DownIofo.阿B直播流对象 = DownIofo.阿B直播流对象;
-                                                重连下载对象.DownIofo.弹幕储存流 = DownIofo.弹幕储存流;
-                                                重连下载对象.DownIofo.礼物储存流 = DownIofo.礼物储存流;
                                                 重连下载对象.DownIofo.下载状态 = false;
                                                 重连下载对象.DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
                                                 重连下载对象.DownIofo.备注 = "服务器主动断开连接，直播结束";
@@ -591,11 +590,8 @@ namespace Auxiliary
                                                 {
                                                     FlvMethod.转码(DownIofo.文件保存路径);
                                                 }
-                                                DownIofo.备注 = "服务器主动断开连接，直播结束";
                                                 重连下载对象.DownIofo.下载状态 = false;
                                                 重连下载对象.DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
-                                                DownIofo.下载状态 = false;
-                                                DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
                                                 下载结束提醒(true, "下载任务结束", 重连下载对象.DownIofo);
                                             }
                                             catch (Exception){}
@@ -608,30 +604,21 @@ namespace Auxiliary
                                                 Thread.Sleep(10000);
                                                 if (重连下载对象.DownIofo.已下载大小bit > 5000)
                                                 {
-                                                    DownIofo.下载状态 = false;
-                                                    DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
-                                                    下载结束提醒(true, "下载任务结束", DownIofo);
                                                     重连下载对象.DownIofo.备注 = "完成重连，正在续命..";
-                                                    //下载对象.DownIofo.下载状态 = true;
                                                     return;
                                                 }
                                                 if (!bilibili.根据房间号获取房间信息.是否正在直播(DownIofo.房间_频道号,true))
                                                 {
                                                     重连下载对象.DownIofo.备注 = "停止直播";
-                                                    DownIofo.备注 = "直播停止，下载完成下载完成";    
                                                     重连下载对象.DownIofo.下载状态 = false;
                                                     重连下载对象.DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
-                                                    DownIofo.下载状态 = false;
-                                                    DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
                                                     重连下载对象.DownIofo.WC.CancelAsync();
                                                     MMPU.DownList.Remove(重连下载对象);
-                                                    下载结束提醒(true, "下载任务结束", DownIofo);
                                                     下载结束提醒(true, "下载任务结束", 重连下载对象.DownIofo);
                                                     return;
                                                 }
                                             }
                                         })).Start();
-                                        DownIofo.下载状态 = false;
                                         break;
                                     }
                                 default:
@@ -683,7 +670,7 @@ namespace Auxiliary
                         try
                         {
                             下载对象.DownIofo.备注 = "新建续下载对象出现异常，放弃新建任务";
-                            下载结束提醒(true,"下载任务结束", DownIofo);
+                            下载结束提醒(true,"下载任务结束", 下载对象.DownIofo);
                             下载对象.DownIofo.下载状态 = false;
                             下载对象.DownIofo.结束时间 = Convert.ToInt32((DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, 0)).TotalSeconds);
                             下载对象.DownIofo.WC.CancelAsync();


### PR DESCRIPTION
在原先的代码中，重连时所有分支都会调用`下载结束提醒(true, "下载任务结束", DownIofo);`，第一个参数为`true`会导致弹幕流和礼物流断开，该PR将流程修改为调用`下载结束提醒(false, "下载任务结束", DownIofo);`，第一个参数为`false`从而只断开下载流而不断开弹幕流和礼物流，并将弹幕流和礼物流转移到重连对象中（原先的代码有部分分支没有进行转移）。
