### PR TITLE
保证合并后的文件名与弹幕/礼物文件名一致

### DIFF
--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -736,10 +736,12 @@ namespace Auxiliary
         public static string 下载完成合并FLV(DownIofoData downIofo, bool 是否直播结束)
         {
             string filename = string.Empty;
+            string mergedFilename = string.Empty;
             List<string> DelFileList = new List<string>();
             if (downIofo.继承.待合并文件列表.Count>1)
             {
                 filename = downIofo.继承.待合并文件列表[0];
+                mergedFilename = filename.Replace(".flv", "合并.flv");
                
                 for (int i = 0; i< downIofo.继承.待合并文件列表.Count-1; i++)
                 {
@@ -754,7 +756,8 @@ namespace Auxiliary
                     if(string.IsNullOrEmpty(BB))
                     {
                         InfoLog.InfoPrintf($"{downIofo.房间_频道号}:{downIofo.主播名称}因为网络连接不稳定，无法获取文件头，放弃合并该flv",InfoLog.InfoClass.下载必要提示);
-                        return filename;
+                        System.IO.File.Move(filename, mergedFilename);
+                        return mergedFilename;
                     }
                     filename = BB;
                 }
@@ -763,7 +766,8 @@ namespace Auxiliary
             {
                 MMPU.文件删除委托(item, "FLV合并任务");
             }
-            return filename;
+            System.IO.File.Move(filename, mergedFilename);
+            return mergedFilename;
         }
         public static string 转换下载大小数据格式(double size)
         {


### PR DESCRIPTION
当前代码中，合并后的文件名和第一个flv文件名使用了不同的时间戳，而弹幕/礼物文件名和第一个flv文件名使用了相同的时间戳，这导致无法依靠文件名匹配录播文件和弹幕/礼物文件。

该PR在合并结束后将合并后的文件重命名为第一个flv文件名加上“合并”后缀的格式，修复了该问题。