### PR TITLE
修复内核版本低于3.14时 MemAvailable 不可用导致系统总览页面无法加载的问题

### DIFF
--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -767,6 +767,9 @@ namespace Auxiliary
         }
         public static string 转换下载大小数据格式(double size)
         {
+            if (size < 0) {
+                return "未知";
+            }
             if (size <= 1024)
             {
                 return size.ToString("F2") + "B";

--- a/Auxiliary/InfoLog.cs
+++ b/Auxiliary/InfoLog.cs
@@ -306,7 +306,14 @@ namespace Auxiliary
                 //    BB += $"<br/>容量:{item.Size} 已使用:{item.Used} 剩余空间:{item.Avail}  使用率:{item.Usage}";
                 //}
                 LinuxInfo.MemInfo Men = LinuxInfo.ServerConfig.读取内存信息();
-                BB += $"<br/>可使用内存:{Downloader.转换下载大小数据格式(double.Parse(Men.Available.Split(' ')[0]) * 1024.0)} 总内存大小:{Downloader.转换下载大小数据格式(double.Parse(Men.Total.Split(' ')[0]) * 1024.0)}</body></html>";
+                if (Men.Available is null) {
+                    Men.Available = "-1";
+                }
+                if (Men.Total is null)
+                {
+                    Men.Total = "-1";
+                }
+                BB += $"<br/>可使用内存:{Downloader.转换下载大小数据格式(double.Parse(Men.Available) * 1024.0)} 总内存大小:{Downloader.转换下载大小数据格式(double.Parse(Men.Total) * 1024.0)}</body></html>";
             }
             BB += InfoLog.DownloaderInfoPrintf(1);
             return BB;
@@ -514,13 +521,13 @@ namespace Auxiliary
                         {
                             count++;
                             var tt = item.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-                            memInfo.Total = tt[1].Trim();
+                            memInfo.Total = tt[1].Trim().Split(' ')[0];
                         }
                         else if (item.StartsWith("MemAvailable:"))
                         {
                             count++;
                             var tt = item.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-                            memInfo.Available = tt[1].Trim();
+                            memInfo.Available = tt[1].Trim().Split(' ')[0];
                         }
                         if (count >= 2) break;
                     }


### PR DESCRIPTION
当Linux内核版本低于3.14时，`/proc/meminfo`中无法解析到`MemAvailable`，导致系统总览页面在加载过程中崩溃。
由于3.14是比较旧的内核版本，目前的修复方式是当无法解析到`MemAvailable`时，将内存信息设为未知。