### PR TITLE
配置文件读取时目录判断的修复

### DIFF
--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -366,7 +366,7 @@ namespace Auxiliary
             if (MMPU.下载储存目录 == 缓存路径)
             {
                 保存路径 = 缓存路径 + 平台 + "_" + 主播名称 + "_" + 唯一码 + "/";
-                if (!Directory.Exists(保存路径))//如果不存在就创建文件夹
+                if (Directory.Exists(保存路径))//如果不存在就创建文件夹
                 {
                     Directory.CreateDirectory(保存路径);
                 }
@@ -496,20 +496,6 @@ namespace Auxiliary
                         }
                         if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                         {
-                            /*
-                             * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
-                             * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
-                             * 需后续对该bug完整修复
-                             */
-                            if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径)) 
-                            {
-                                if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
-                                {
-                                    DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
-                                }
-                                DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
-                                DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
-                            }
                             DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                             if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                             {
@@ -595,23 +581,7 @@ namespace Auxiliary
                                                 }
                                                 if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                                                 {
-                                                    if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
-                                                    {
-                                                        /*
-                                                         * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
-                                                         * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
-                                                         * 需后续对该bug完整修复
-                                                         */
-                                                        if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径))
-                                                        {
-                                                            if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
-                                                            {
-                                                                DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
-                                                            }
-                                                            DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
-                                                            DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
-                                                        }
-                                                        DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
+                                                    DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                                                     if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                                                     {
                                                         DownIofo.文件保存路径 = DownIofo.继承.合并后的文件路径;

--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -366,7 +366,7 @@ namespace Auxiliary
             if (MMPU.下载储存目录 == 缓存路径)
             {
                 保存路径 = 缓存路径 + 平台 + "_" + 主播名称 + "_" + 唯一码 + "/";
-                if (Directory.Exists(保存路径))//如果不存在就创建文件夹
+                if (!Directory.Exists(保存路径))//如果不存在就创建文件夹
                 {
                     Directory.CreateDirectory(保存路径);
                 }

--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -366,7 +366,7 @@ namespace Auxiliary
             if (MMPU.下载储存目录 == 缓存路径)
             {
                 保存路径 = 缓存路径 + 平台 + "_" + 主播名称 + "_" + 唯一码 + "/";
-                if (Directory.Exists(保存路径))//如果不存在就创建文件夹
+                if (!Directory.Exists(保存路径))//如果不存在就创建文件夹
                 {
                     Directory.CreateDirectory(保存路径);
                 }
@@ -496,6 +496,20 @@ namespace Auxiliary
                         }
                         if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                         {
+                            /*
+                             * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
+                             * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
+                             * 需后续对该bug完整修复
+                             */
+                            if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径)) 
+                            {
+                                if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
+                                {
+                                    DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
+                                }
+                                DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
+                                DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
+                            }
                             DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                             if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                             {
@@ -581,7 +595,23 @@ namespace Auxiliary
                                                 }
                                                 if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                                                 {
-                                                    DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
+                                                    if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
+                                                    {
+                                                        /*
+                                                         * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
+                                                         * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
+                                                         * 需后续对该bug完整修复
+                                                         */
+                                                        if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径))
+                                                        {
+                                                            if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
+                                                            {
+                                                                DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
+                                                            }
+                                                            DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
+                                                            DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
+                                                        }
+                                                        DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                                                     if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                                                     {
                                                         DownIofo.文件保存路径 = DownIofo.继承.合并后的文件路径;

--- a/Auxiliary/MMPU.cs
+++ b/Auxiliary/MMPU.cs
@@ -234,7 +234,7 @@ namespace Auxiliary
             //房间配置文件
             MMPU.下载储存目录 = MMPU.读取exe默认配置文件("file", "./tmp/");
             CheckPath(ref MMPU.下载储存目录);
-            if (Directory.Exists("./tmp"))
+            if (!Directory.Exists("./tmp"))
             {
                 Directory.CreateDirectory("./tmp");
             }

--- a/Auxiliary/MMPU.cs
+++ b/Auxiliary/MMPU.cs
@@ -233,7 +233,8 @@ namespace Auxiliary
             InfoLog.InfoPrintf($"配置文件初始化任务[RoomConfigFile]:{RoomInit.RoomConfigFile}", InfoLog.InfoClass.Debug);
             //房间配置文件
             MMPU.下载储存目录 = MMPU.读取exe默认配置文件("file", "./tmp/");
-            if(Directory.Exists("./tmp"))
+            CheckPath(ref MMPU.下载储存目录);
+            if (Directory.Exists("./tmp"))
             {
                 Directory.CreateDirectory("./tmp");
             }
@@ -1642,6 +1643,16 @@ namespace Auxiliary
                 [DllImport("Kernel32")]
                 public static extern IntPtr GetProcAddress(IntPtr handle, string funcname);
             }
+        }
+        /// <summary>
+        /// 检查路径末尾分隔符并修正
+        /// </summary>
+        /// <param name="x">待检查修改路径</param>
+        /// <returns>无返回</returns>
+        private static void CheckPath(ref string x)
+        {
+            if (x.Substring(x.Length - 1, 1) != "/" && x.Substring(x.Length - 1, 1) != "\\") x += '/';
+            return;
         }
     }
 }


### PR DESCRIPTION
新增目录末尾分隔符检测及自动修复，避免配置文件中输入"./tmp"，导致下载目录发生错误
tmp目录存在检测判断有误，已修复