### PR TITLE
暂时解决合并FLV时的错误

### DIFF
--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -496,23 +496,6 @@ namespace Auxiliary
                         }
                         if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                         {
-                            /*
-                             * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
-                             * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
-                             * 需后续对该bug完整修复
-                             */
-                            if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径))
-                            {
-                                if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
-                                {
-                                    DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
-                                }
-                                DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
-                                DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
-                            }
-                            /*
-                             * 修复结束
-                             */
                             DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                             if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                             {
@@ -548,23 +531,13 @@ namespace Auxiliary
                             {
                                 case "bilibili":
                                     {
-                                        if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
+                                        if (!DownIofo.是否是播放任务)
                                         {
-                                            //DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo.继承.继承的下载文件路径, DownIofo.文件保存路径, false);
-                                            if(DownIofo.继承.待合并文件列表.Count==0)
-                                            {
-                                                DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
-                                                InfoLog.InfoPrintf($"{DownIofo.房间_频道号}:{DownIofo.主播名称}下载任务续下，历史文件加入待合并文件列表:{DownIofo.继承.继承的下载文件路径}", InfoLog.InfoClass.下载必要提示);
-                                            }
                                             DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
                                             InfoLog.InfoPrintf($"{DownIofo.房间_频道号}:{DownIofo.主播名称}下载任务续下，历史文件加入待合并文件列表:{DownIofo.文件保存路径}", InfoLog.InfoClass.下载必要提示);
-                                            //if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
-                                            //{
-                                            //    DownIofo.文件保存路径 = DownIofo.继承.合并后的文件路径;
-                                            //}
                                         }
                                         DownIofo.下载状态 = false;
-                                        Downloader 重连下载对象 = Downloader.新建下载对象(
+                                       Downloader 重连下载对象 = Downloader.新建下载对象(
                                             DownIofo.平台,
                                             DownIofo.房间_频道号,
                                             bilibili.根据房间号获取房间信息.获取标题(DownIofo.房间_频道号),
@@ -598,23 +571,6 @@ namespace Auxiliary
                                                 }
                                                 if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                                                 {
-                                                    /*
-                                                     * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
-                                                     * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
-                                                     * 需后续对该bug完整修复
-                                                     */
-                                                    if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径))
-                                                    {
-                                                        if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
-                                                        {
-                                                            DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
-                                                        }
-                                                        DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
-                                                        DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
-                                                    }
-                                                    /*
-                                                     * 修复结束
-                                                     */
                                                     DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                                                     if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                                                     {

--- a/Auxiliary/Downloader.cs
+++ b/Auxiliary/Downloader.cs
@@ -496,6 +496,23 @@ namespace Auxiliary
                         }
                         if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                         {
+                            /*
+                             * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
+                             * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
+                             * 需后续对该bug完整修复
+                             */
+                            if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径))
+                            {
+                                if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
+                                {
+                                    DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
+                                }
+                                DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
+                                DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
+                            }
+                            /*
+                             * 修复结束
+                             */
                             DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                             if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                             {
@@ -581,6 +598,23 @@ namespace Auxiliary
                                                 }
                                                 if (DownIofo.继承.是否为继承对象 && !DownIofo.是否是播放任务)
                                                 {
+                                                    /*
+                                                     * 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
+                                                     * 解决方法：如果该文件不在列表中，则把该文件加入到列表里
+                                                     * 需后续对该bug完整修复
+                                                     */
+                                                    if (!DownIofo.继承.待合并文件列表.Exists(p => p == DownIofo.继承.继承的下载文件路径))
+                                                    {
+                                                        if (DownIofo.继承.待合并文件列表.Last() == DownIofo.文件保存路径)
+                                                        {
+                                                            DownIofo.继承.待合并文件列表.RemoveAt(DownIofo.继承.待合并文件列表.Count - 1);
+                                                        }
+                                                        DownIofo.继承.待合并文件列表.Add(DownIofo.继承.继承的下载文件路径);
+                                                        DownIofo.继承.待合并文件列表.Add(DownIofo.文件保存路径);
+                                                    }
+                                                    /*
+                                                     * 修复结束
+                                                     */
                                                     DownIofo.继承.合并后的文件路径 = 下载完成合并FLV(DownIofo, true);
                                                     if (!string.IsNullOrEmpty(DownIofo.继承.合并后的文件路径))
                                                     {


### PR DESCRIPTION
* 暂时解决【续下任务进行时OBS未结束推流，直接从b站直播间关闭直播，导致无法正常合并最后一个文件】的错误
* 解决方法：如果该文件不在列表中，则把该文件加入到列表里
* 需后续对该bug完整修复

### Bug描述
> 正常结束直播流程：关闭OBS推流，关闭b站直播间直播
> 异常结束直播流程：直接关闭b站直播间直播
> 2文件：obs中断一次，最终未合并前生成2个视频文件
> 3文件：obs中断两次，最终未合并前生成3个视频文件

obs中断一次，也就是**新增下载任务**后的第一次**续下任务**，当直播异常结束时，会导致**待合并文件列表**未包含当前下载文件，同时**文件保存路径**也未更新为续下任务的路径

猜测bug发生的原因可能和网络环境有关，目前bug可复现。经过暂时修复后可以正常合并所有文件。

具体的运行截图和参数已打包上传，png文件为关键变量监视，txt文件为DownIofo详情。最主要的bug在“异常结束 2文件”中出现。3文件时有时候会出bug，有时候正常。
[log.zip](https://github.com/CHKZL/DDTV2/files/6205813/log.zip)