### PR TITLE
改进WriteBE

### DIFF
--- a/DDTV_Core/SystemAssembly/BilibiliModule/API/WebSocket/LiveChatScript.cs
+++ b/DDTV_Core/SystemAssembly/BilibiliModule/API/WebSocket/LiveChatScript.cs
@@ -10,13 +10,13 @@ namespace DDTV_Core.SystemAssembly.BilibiliModule.API.WebSocket
         internal static void WriteBE(this BinaryWriter writer, int value)
         {
             if(BitConverter.IsLittleEndian)
-                value = ReverseEndianness(value)
+                value = ReverseEndianness(value);
             writer.Write(value);
         }
         internal static void WriteBE(this BinaryWriter writer, ushort value)
         {
             if(BitConverter.IsLittleEndian)
-                value = ReverseEndianness(value)
+                value = ReverseEndianness(value);
             writer.Write(value);
         }
         internal static unsafe void SwapBytes(byte* ptr, int length)

--- a/DDTV_Core/SystemAssembly/BilibiliModule/API/WebSocket/LiveChatScript.cs
+++ b/DDTV_Core/SystemAssembly/BilibiliModule/API/WebSocket/LiveChatScript.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Buffers;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace DDTV_Core.SystemAssembly.BilibiliModule.API.WebSocket
 {
@@ -11,15 +9,16 @@ namespace DDTV_Core.SystemAssembly.BilibiliModule.API.WebSocket
     {
         internal static void WriteBE(this BinaryWriter writer, int value)
         {
-            unsafe { SwapBytes((byte*)&value, 4); }
+            if(BitConverter.IsLittleEndian)
+			    value = ReverseEndianness(value)
             writer.Write(value);
         }
         internal static void WriteBE(this BinaryWriter writer, ushort value)
         {
-            unsafe { SwapBytes((byte*)&value, 2); }
+            if(BitConverter.IsLittleEndian)
+			    value = ReverseEndianness(value)
             writer.Write(value);
         }
-
         internal static unsafe void SwapBytes(byte* ptr, int length)
         {
             for (int i = 0 ; i < length / 2 ; ++i)

--- a/DDTV_Core/SystemAssembly/BilibiliModule/API/WebSocket/LiveChatScript.cs
+++ b/DDTV_Core/SystemAssembly/BilibiliModule/API/WebSocket/LiveChatScript.cs
@@ -10,13 +10,13 @@ namespace DDTV_Core.SystemAssembly.BilibiliModule.API.WebSocket
         internal static void WriteBE(this BinaryWriter writer, int value)
         {
             if(BitConverter.IsLittleEndian)
-			    value = ReverseEndianness(value)
+                value = ReverseEndianness(value)
             writer.Write(value);
         }
         internal static void WriteBE(this BinaryWriter writer, ushort value)
         {
             if(BitConverter.IsLittleEndian)
-			    value = ReverseEndianness(value)
+                value = ReverseEndianness(value)
             writer.Write(value);
         }
         internal static unsafe void SwapBytes(byte* ptr, int length)


### PR DESCRIPTION
WriteBE自行检测系统端序，在大端序机器（MacOS等）上不进行逆序操作
另将SwapBytes改为从.NET Core 2.1起，系统库自带的BinaryPrimitives.ReverseEndianness