### PR TITLE
新增托盘右键菜单,更新WpfUI版本，加注释，后面忘了

### DIFF
--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -43,7 +43,8 @@
     <PackageReference Include="Net.Codecrete.QrCodeGenerator" Version="2.0.5" />
     <PackageReference Include="Notification.Wpf" Version="8.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
-    <PackageReference Include="WPF-UI" Version="3.0.5" />
+    <PackageReference Include="WPF-UI" Version="4.0.0" />
+    <PackageReference Include="WPF-UI.Tray" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Desktop/MainWindow.xaml
+++ b/Desktop/MainWindow.xaml
@@ -78,6 +78,7 @@
         </Grid>
         <Grid>
             <local:NotifyIcon x:Name="notifyIcon" />
+            <!--增加托盘图标控件-->
         </Grid>
         <Grid>
             <ui:SnackbarPresenter Height="150" Name="MainSnackbar" VerticalAlignment="Bottom"></ui:SnackbarPresenter>

--- a/Desktop/MainWindow.xaml
+++ b/Desktop/MainWindow.xaml
@@ -77,10 +77,11 @@
             <ui:TitleBar Margin="0,2,0,0"  Name="UI_TitleBar" Height="30" Title="{Binding ProgramTitle}" Grid.Row="0" Icon="pack://application:,,,/DDTV.ico" />
         </Grid>
         <Grid>
+            <local:NotifyIcon x:Name="notifyIcon" />
+        </Grid>
+        <Grid>
             <ui:SnackbarPresenter Height="150" Name="MainSnackbar" VerticalAlignment="Bottom"></ui:SnackbarPresenter>
         </Grid>
         <ContentPresenter x:Name="RootContentDialogPresenter" />
     </Grid>
-   
-    
 </ui:FluentWindow>

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -102,7 +102,6 @@ namespace Desktop
             SnackbarService = Desktop.App._MainSnackbarServiceProvider.GetRequiredService<ISnackbarService>();
             SnackbarService.SetSnackbarPresenter(MainSnackbar);
             //初始化托盘
-            //notify();    已弃用
             InitializeNotifyIcon();
 			//初始化确认窗口
 			_contentDialogService.SetDialogHost(RootContentDialogPresenter);
@@ -234,7 +233,9 @@ namespace Desktop
         }
         
 
-
+        /// <summary>
+        /// 初始化托盘图标，原有托盘图标动作重写到NotifyIcon控件内
+        /// </summary>
 		private void InitializeNotifyIcon()
 		{
 			NotifyIcon notifyIconWindow = new NotifyIcon();
@@ -254,19 +255,6 @@ namespace Desktop
                 this.Hide();
             }
         }
-        /// <summary>
-        /// 双击托盘ICON事件
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-
-        private void NotifyIcon_Click(object? sender, EventArgs e)
-        {
-            this.Show();  // 显示窗口
-            this.WindowState = WindowState.Normal;  // 设置窗口状态为正常
-        }
-
-       
 
 		/// <summary>
 		/// 开播事件，触发开播提醒

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -242,9 +242,13 @@ namespace Desktop
 			ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
 			//添加菜单项
 			ToolStripMenuItem rightClickExit = new ToolStripMenuItem("退出");
+            ToolStripMenuItem rightClickForceShow = new ToolStripMenuItem("强制显示");
 			rightClickExit.Click += this.rightClickExit;
-			contextMenuStrip.Items.Add(rightClickExit);
+            rightClickForceShow.Click += this.rightClickForceShow;
 
+			contextMenuStrip.Items.Add(rightClickExit);
+            contextMenuStrip.Items.Add(rightClickForceShow);
+    
 			notifyIcon.ContextMenuStrip = contextMenuStrip;
 		}
 
@@ -289,6 +293,19 @@ namespace Desktop
 					Environment.Exit(-114514);
 				}
 			}
+		}
+		///<summary>
+		///右键强制显示
+		///</summary>
+		private void rightClickForceShow(object? sender, EventArgs e)
+		{
+
+			this.Show();
+			this.WindowState= WindowState.Normal;
+			this.Left = (System.Windows.SystemParameters.PrimaryScreenWidth - this.ActualWidth) / 2;
+			this.Top = (System.Windows.SystemParameters.PrimaryScreenHeight - this.ActualHeight) / 2;
+			this.Activate();
+			
 		}
 
 		/// <summary>

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -238,7 +238,15 @@ namespace Desktop
             notifyIcon.Visible = true;
             notifyIcon.DoubleClick += NotifyIcon_Click;
             StateChanged += MainWindow_StateChanged; ;
-        }
+			//新增右键菜单
+			ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
+			//添加菜单项
+			ToolStripMenuItem rightClickExit = new ToolStripMenuItem("退出");
+			rightClickExit.Click += this.rightClickExit;
+			contextMenuStrip.Items.Add(rightClickExit);
+
+			notifyIcon.ContextMenuStrip = contextMenuStrip;
+		}
 
         /// <summary>
         /// 窗口缩小事件
@@ -265,15 +273,31 @@ namespace Desktop
             this.WindowState = WindowState.Normal;  // 设置窗口状态为正常
         }
 
+		/// <summary>
+		/// 右键菜单退出
+		/// </summary>
+		private void rightClickExit(object? sender, EventArgs e)
+		{
+			if (!IsProgrammaticClose)
+			{
+				System.Windows.MessageBoxResult result = MessageBox.Show("确认要关闭DDTV吗？\r\n关闭后所有录制任务以及播放窗口均会结束。", "关闭确认", System.Windows.MessageBoxButton.YesNo, MessageBoxImage.Question);
+				if (result == System.Windows.MessageBoxResult.Yes)
+				{
 
+					DataPage.Timer_DataPage?.Dispose();
+					DataSource.LoginStatus.Timer_LoginStatus?.Dispose();
+					Environment.Exit(-114514);
+				}
+			}
+		}
 
-        /// <summary>
-        /// 开播事件，触发开播提醒
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        /// <exception cref="NotImplementedException"></exception>
-        private void DetectRoom_LiveStart(object? sender, (RoomCardClass Card, bool Danma_MessageReceived) LiveInvoke)
+		/// <summary>
+		/// 开播事件，触发开播提醒
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		/// <exception cref="NotImplementedException"></exception>
+		private void DetectRoom_LiveStart(object? sender, (RoomCardClass Card, bool Danma_MessageReceived) LiveInvoke)
         {
             RoomCardClass roomCard = LiveInvoke.Card;
             List<TriggerType> triggerTypes = sender as List<TriggerType> ?? new List<TriggerType>();

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -23,14 +23,15 @@ namespace Desktop
     /// </summary>
     public partial class MainWindow : FluentWindow
     {
-        /// <summary>
-        /// 后台托盘
-        /// </summary>
-        //private Wpf.Ui.Tray.Controls.NotifyIcon notifyIcon = null;
-        /// <summary>
-        /// 系统托盘通知
-        /// </summary>
-        public static NotificationManager notificationManager = new NotificationManager();
+		/// <summary>
+		/// 后台托盘     改为NotifyIcon控件实现，原代码撇了
+		/// </summary>
+
+
+		/// <summary>
+		/// 系统托盘通知
+		/// </summary>
+		public static NotificationManager notificationManager = new NotificationManager();
         /// <summary>
         /// 确认窗口
         /// </summary>
@@ -83,10 +84,10 @@ namespace Desktop
 
         }
 
-        /// <summary>
-        /// 初始化各种页面内容
-        /// </summary>
-        public void Init()
+		/// <summary>
+		/// 初始化各种页面内容
+		/// </summary>
+		public void Init()
         {
             //设置房间卡片列表页定时任务
             DataPage.Timer_DataPage = new Timer(DataPage.Refresher, null, 1, 1000);
@@ -102,7 +103,6 @@ namespace Desktop
             SnackbarService = Desktop.App._MainSnackbarServiceProvider.GetRequiredService<ISnackbarService>();
             SnackbarService.SetSnackbarPresenter(MainSnackbar);
             //初始化托盘
-            //notify();    已弃用
             InitializeNotifyIcon();
 			//初始化确认窗口
 			_contentDialogService.SetDialogHost(RootContentDialogPresenter);
@@ -234,7 +234,9 @@ namespace Desktop
         }
         
 
-
+        /// <summary>
+        /// 初始化托盘图标，原有托盘图标动作重写到NotifyIcon控件内
+        /// </summary>
 		private void InitializeNotifyIcon()
 		{
 			NotifyIcon notifyIconWindow = new NotifyIcon();
@@ -254,19 +256,6 @@ namespace Desktop
                 this.Hide();
             }
         }
-        /// <summary>
-        /// 双击托盘ICON事件
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-
-        private void NotifyIcon_Click(object? sender, EventArgs e)
-        {
-            this.Show();  // 显示窗口
-            this.WindowState = WindowState.Normal;  // 设置窗口状态为正常
-        }
-
-       
 
 		/// <summary>
 		/// 开播事件，触发开播提醒

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace Desktop
         /// <summary>
         /// 后台托盘
         /// </summary>
-        private NotifyIcon notifyIcon = null;
+        //private Wpf.Ui.Tray.Controls.NotifyIcon notifyIcon = null;
         /// <summary>
         /// 系统托盘通知
         /// </summary>
@@ -73,7 +73,8 @@ namespace Desktop
                 Thread.Sleep(1000);
                 //初始化各种page
                 Init();
-            }
+				InitializeNotifyIcon();
+			}
             catch (Exception ex)
             {
                 System.Windows.MessageBox.Show($"UI初始化出现重大错误，错误堆栈{ex.ToString()}");
@@ -101,9 +102,10 @@ namespace Desktop
             SnackbarService = Desktop.App._MainSnackbarServiceProvider.GetRequiredService<ISnackbarService>();
             SnackbarService.SetSnackbarPresenter(MainSnackbar);
             //初始化托盘
-            notify();
-            //初始化确认窗口
-            _contentDialogService.SetDialogHost(RootContentDialogPresenter);
+            //notify();    已弃用
+            InitializeNotifyIcon();
+			//初始化确认窗口
+			_contentDialogService.SetDialogHost(RootContentDialogPresenter);
             //初始化标题和远程模式标志以及检查远程和本地版本号一致性
             InitializeTitleMode();
             //监听开播事件，用于开播提醒
@@ -230,35 +232,22 @@ namespace Desktop
             catch (Exception) { }
             return null;
         }
-        private void notify()
-        {
-            notifyIcon = new System.Windows.Forms.NotifyIcon();
-            notifyIcon.Text = "DDTV";
-            notifyIcon.Icon = new System.Drawing.Icon("DDTV.ico");
-            notifyIcon.Visible = true;
-            notifyIcon.DoubleClick += NotifyIcon_Click;
-            StateChanged += MainWindow_StateChanged; ;
-			//新增右键菜单
-			ContextMenuStrip contextMenuStrip = new ContextMenuStrip();
-			//添加菜单项
-			ToolStripMenuItem rightClickExit = new ToolStripMenuItem("退出");
-            ToolStripMenuItem rightClickForceShow = new ToolStripMenuItem("强制显示");
-			rightClickExit.Click += this.rightClickExit;
-            rightClickForceShow.Click += this.rightClickForceShow;
+        
 
-			contextMenuStrip.Items.Add(rightClickExit);
-            contextMenuStrip.Items.Add(rightClickForceShow);
-    
-			notifyIcon.ContextMenuStrip = contextMenuStrip;
+
+		private void InitializeNotifyIcon()
+		{
+			NotifyIcon notifyIconWindow = new NotifyIcon();
+			StateChanged += MainWindow_StateChanged;
 		}
 
-        /// <summary>
-        /// 窗口缩小事件
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        /// <exception cref="NotImplementedException"></exception>
-        private void MainWindow_StateChanged(object? sender, EventArgs e)
+		/// <summary>
+		/// 窗口缩小事件
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		/// <exception cref="NotImplementedException"></exception>
+		private void MainWindow_StateChanged(object? sender, EventArgs e)
         {
             if (Config.Core_RunConfig._ZoomOutMode != 0 && this.WindowState == WindowState.Minimized)
             {
@@ -277,36 +266,7 @@ namespace Desktop
             this.WindowState = WindowState.Normal;  // 设置窗口状态为正常
         }
 
-		/// <summary>
-		/// 右键菜单退出
-		/// </summary>
-		private void rightClickExit(object? sender, EventArgs e)
-		{
-			if (!IsProgrammaticClose)
-			{
-				System.Windows.MessageBoxResult result = MessageBox.Show("确认要关闭DDTV吗？\r\n关闭后所有录制任务以及播放窗口均会结束。", "关闭确认", System.Windows.MessageBoxButton.YesNo, MessageBoxImage.Question);
-				if (result == System.Windows.MessageBoxResult.Yes)
-				{
-
-					DataPage.Timer_DataPage?.Dispose();
-					DataSource.LoginStatus.Timer_LoginStatus?.Dispose();
-					Environment.Exit(-114514);
-				}
-			}
-		}
-		///<summary>
-		///右键强制显示
-		///</summary>
-		private void rightClickForceShow(object? sender, EventArgs e)
-		{
-
-			this.Show();
-			this.WindowState= WindowState.Normal;
-			this.Left = (System.Windows.SystemParameters.PrimaryScreenWidth - this.ActualWidth) / 2;
-			this.Top = (System.Windows.SystemParameters.PrimaryScreenHeight - this.ActualHeight) / 2;
-			this.Activate();
-			
-		}
+       
 
 		/// <summary>
 		/// 开播事件，触发开播提醒

--- a/Desktop/MainWindow.xaml.cs
+++ b/Desktop/MainWindow.xaml.cs
@@ -23,14 +23,15 @@ namespace Desktop
     /// </summary>
     public partial class MainWindow : FluentWindow
     {
-        /// <summary>
-        /// 后台托盘
-        /// </summary>
-        //private Wpf.Ui.Tray.Controls.NotifyIcon notifyIcon = null;
-        /// <summary>
-        /// 系统托盘通知
-        /// </summary>
-        public static NotificationManager notificationManager = new NotificationManager();
+		/// <summary>
+		/// 后台托盘     改为NotifyIcon控件实现，原代码撇了
+		/// </summary>
+
+
+		/// <summary>
+		/// 系统托盘通知
+		/// </summary>
+		public static NotificationManager notificationManager = new NotificationManager();
         /// <summary>
         /// 确认窗口
         /// </summary>
@@ -83,10 +84,10 @@ namespace Desktop
 
         }
 
-        /// <summary>
-        /// 初始化各种页面内容
-        /// </summary>
-        public void Init()
+		/// <summary>
+		/// 初始化各种页面内容
+		/// </summary>
+		public void Init()
         {
             //设置房间卡片列表页定时任务
             DataPage.Timer_DataPage = new Timer(DataPage.Refresher, null, 1, 1000);

--- a/Desktop/NotifyIcon.xaml
+++ b/Desktop/NotifyIcon.xaml
@@ -14,7 +14,8 @@
         <tray:NotifyIcon.Menu>
             <ContextMenu>
                 <!-- 定义上下文菜单项 -->
-                <MenuItem Name="exitMenu" Header="退出"/> 
+                <MenuItem Name="exitMenu" Header="退出"/>
+                <Separator />
                 <MenuItem Name="forceShowMenu" Header="强制显示" /> 
             </ContextMenu>
         </tray:NotifyIcon.Menu>

--- a/Desktop/NotifyIcon.xaml
+++ b/Desktop/NotifyIcon.xaml
@@ -2,18 +2,20 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:tray="http://schemas.lepo.co/wpfui/2022/xaml/tray"
-        xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-        >
+        xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    <!-- 定义托盘图标控件 -->
     <tray:NotifyIcon
-        TooltipText="DDTV"
-        Icon="pack://application:,,,/Assets/DDTV.ico"
-         Visibility="Visible"
-        LeftClick="NotifyIcon_Click">
+        TooltipText="DDTV" 
+        Icon="pack://application:,,,/Assets/DDTV.ico" 
+        Visibility="Visible" 
+        LeftClick="NotifyIcon_Click"> 
         
+        <!-- 定义托盘图标的上下文菜单 -->
         <tray:NotifyIcon.Menu>
             <ContextMenu>
-                <MenuItem Name="exitMenu" Header="退出"/>
-                <MenuItem Name="forceShowMenu" Header="强制显示" />
+                <!-- 定义上下文菜单项 -->
+                <MenuItem Name="exitMenu" Header="退出"/> 
+                <MenuItem Name="forceShowMenu" Header="强制显示" /> 
             </ContextMenu>
         </tray:NotifyIcon.Menu>
     </tray:NotifyIcon>

--- a/Desktop/NotifyIcon.xaml
+++ b/Desktop/NotifyIcon.xaml
@@ -14,9 +14,9 @@
         <tray:NotifyIcon.Menu>
             <ContextMenu>
                 <!-- 定义上下文菜单项 -->
-                <MenuItem Name="exitMenu" Header="退出"/>
+                <MenuItem Name="forceShowMenu" Header="强制显示" />             
                 <Separator />
-                <MenuItem Name="forceShowMenu" Header="强制显示" /> 
+                <MenuItem Name="exitMenu" Header="退出"/>
             </ContextMenu>
         </tray:NotifyIcon.Menu>
     </tray:NotifyIcon>

--- a/Desktop/NotifyIcon.xaml
+++ b/Desktop/NotifyIcon.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl x:Class="Desktop.NotifyIcon"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:tray="http://schemas.lepo.co/wpfui/2022/xaml/tray"
+        xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+        >
+    <tray:NotifyIcon
+        TooltipText="DDTV"
+        Icon="pack://application:,,,/Assets/DDTV.ico"
+         Visibility="Visible"
+        LeftClick="NotifyIcon_Click">
+        
+        <tray:NotifyIcon.Menu>
+            <ContextMenu>
+                <MenuItem Name="exitMenu" Header="退出"/>
+                <MenuItem Name="forceShowMenu" Header="强制显示" />
+            </ContextMenu>
+        </tray:NotifyIcon.Menu>
+    </tray:NotifyIcon>
+</UserControl>

--- a/Desktop/NotifyIcon.xaml.cs
+++ b/Desktop/NotifyIcon.xaml.cs
@@ -1,0 +1,72 @@
+﻿using Desktop.Views.Pages;
+using Core;
+using Core.LogModule;
+using Core.RuntimeObject;
+using Desktop.Models;
+using Desktop.Views.Pages;
+using Desktop.Views.Windows;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using Wpf.Ui.Controls;
+
+namespace Desktop
+{
+	public partial class NotifyIcon 
+	{
+		public NotifyIcon()
+		{
+			InitializeComponent();
+			initMenu();
+		}
+		private void initMenu()
+		{
+			exitMenu.Click += RightClickExit;
+			forceShowMenu.Click += rightClickForceShow;
+			 
+		}
+		private void RightClickExit(object sender, RoutedEventArgs e)
+		{
+			if (!MainWindow.IsProgrammaticClose)
+			{
+				System.Windows.MessageBoxResult result = MessageBox.Show("确认要关闭DDTV吗？\r\n关闭后所有录制任务以及播放窗口均会结束。", "关闭确认", System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Question);
+				if (result == System.Windows.MessageBoxResult.Yes)
+				{
+					DataPage.Timer_DataPage?.Dispose();
+					DataSource.LoginStatus.Timer_LoginStatus?.Dispose();
+					Environment.Exit(-114514);
+				}
+			}
+		}
+
+		private void rightClickForceShow(object sender, RoutedEventArgs e)
+		{
+			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+			if (mainWindow != null)
+			{
+				mainWindow.Show();
+				mainWindow.WindowState = WindowState.Normal;
+				mainWindow.Left = (SystemParameters.PrimaryScreenWidth - mainWindow.ActualWidth) / 2;
+				mainWindow.Top = (SystemParameters.PrimaryScreenHeight - mainWindow.ActualHeight) / 2;
+				mainWindow.Activate();
+			}
+		}
+		private void NotifyIcon_Click(object? sender, EventArgs e)
+		{
+			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+			mainWindow.Show();  
+			mainWindow.WindowState = WindowState.Normal; 
+		}
+	}
+	
+}

--- a/Desktop/NotifyIcon.xaml.cs
+++ b/Desktop/NotifyIcon.xaml.cs
@@ -33,7 +33,7 @@ namespace Desktop
 		{
 			exitMenu.Click += RightClickExit;
 			forceShowMenu.Click += rightClickForceShow;
-			 
+			//此处没绑定单击事件，因为单击事件在xaml中已经绑定了XD
 		}
 
 		/// <summary>

--- a/Desktop/NotifyIcon.xaml.cs
+++ b/Desktop/NotifyIcon.xaml.cs
@@ -35,6 +35,12 @@ namespace Desktop
 			forceShowMenu.Click += rightClickForceShow;
 			 
 		}
+
+		/// <summary>
+		/// 右键退出点击动作
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
 		private void RightClickExit(object sender, RoutedEventArgs e)
 		{
 			if (!MainWindow.IsProgrammaticClose)
@@ -49,6 +55,11 @@ namespace Desktop
 			}
 		}
 
+		/// <summary>
+		/// 右键强制显示点击动作
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
 		private void rightClickForceShow(object sender, RoutedEventArgs e)
 		{
 			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
@@ -61,6 +72,12 @@ namespace Desktop
 				mainWindow.Activate();
 			}
 		}
+
+		/// <summary>
+		/// 双击通知栏图标显示主窗口
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
 		private void NotifyIcon_Click(object? sender, EventArgs e)
 		{
 			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;

--- a/Desktop/NotifyIcon.xaml.cs
+++ b/Desktop/NotifyIcon.xaml.cs
@@ -33,8 +33,14 @@ namespace Desktop
 		{
 			exitMenu.Click += RightClickExit;
 			forceShowMenu.Click += rightClickForceShow;
-			 
+			//此处没绑定单击事件，因为单击事件在xaml中已经绑定了XD
 		}
+
+		/// <summary>
+		/// 右键退出点击动作
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
 		private void RightClickExit(object sender, RoutedEventArgs e)
 		{
 			if (!MainWindow.IsProgrammaticClose)
@@ -49,6 +55,11 @@ namespace Desktop
 			}
 		}
 
+		/// <summary>
+		/// 右键强制显示点击动作
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
 		private void rightClickForceShow(object sender, RoutedEventArgs e)
 		{
 			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
@@ -61,6 +72,12 @@ namespace Desktop
 				mainWindow.Activate();
 			}
 		}
+
+		/// <summary>
+		/// 双击通知栏图标显示主窗口
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
 		private void NotifyIcon_Click(object? sender, EventArgs e)
 		{
 			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;


### PR DESCRIPTION
# 描述

新增右键托盘图标菜单，包括退出和强制显示
重写托盘图标控件及功能，影响Desktop/MainWindow.xaml.cs和Desktop/MainWindow.xaml，新增了NotifyIcon.xaml和对应的cs文件
更新WPF-UI的版本从3.0.5至4.0.0 影响Desktop/Desktop.csproj
(是不是还有测试新的ci的功能)

# 怎么测试的？
同#247 
# 核查清单:

_请剔除无关项._

- [ ] 我的代码符合项目的样式规范。
- [x] 我对我的代码进行了自我检查。
- [x] 我已对代码进行注释，特别是晦涩难懂的部分。
        *  *注释可能太多了（？）*
- [x] 我写的代码没蹦出新的警告。
