### PR TITLE
1.更新年份 2.增加mkvtoolnix85.0(没更到最新，实际只需要mkvmerge)

### DIFF
--- a/Core/Tools/Transcode.cs
+++ b/Core/Tools/Transcode.cs
@@ -151,5 +151,103 @@ namespace Core.Tools
 
             LogText = null;
         }
+		/// <summary>
+		/// 使用 MKVToolNix 修复 MKV 文件时长的异步函数
+		/// </summary>
+		/// <param name="before">源文件路径</param>
+		/// <param name="after">目标文件路径</param>
+		/// <param name="Card">可选，房间卡对象</param>
+		/// <returns>Task</returns>
+		public async Task FixDurationWithMkvToolnixAsync(string before, string after)
+		{
+			List<string> LogText = new List<string>();
+			string LogTextAsString = string.Empty;
+            try
+            {
+
+
+                // 构造命令行参数
+                string arguments =
+                    $"--ui-language zh_CN --priority lower --output \"{after}\" " +
+                    "--language 0:und --color-matrix-coefficients 0:1 --color-transfer-characteristics 0:1 " +
+                    "--color-primaries 0:1 --fix-bitstream-timing-information 0:1 --language 1:und " +
+                    $"\"(\" \"{before}\" \")\" --track-order 0:0,0:1";
+
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo()
+                    {
+                        Arguments = arguments,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardInput = true,
+                        StandardOutputEncoding = Encoding.UTF8,
+                    }
+                };
+
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    try { if (!string.IsNullOrEmpty(e.Data)) LogText.Add(e.Data); } catch { }
+                };
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    try { if (!string.IsNullOrEmpty(e.Data)) LogText.Add(e.Data); } catch { }
+                };
+
+                // 可在config里增加usingCustomMKVmerge增加自定义路径功能
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    //if (!string.IsNullOrEmpty(Config.Core_RunConfig._UsingCustomMKVMERGE) && File.Exists(Config.Core_RunConfig._UsingCustomMKVMERGE))
+                    //{
+                    //	process.StartInfo.FileName = Config.Core_RunConfig._UsingCustomMKVMERGE;
+                    //}
+                    //else 
+                    if (File.Exists("./Plugins/MKVToolNix/mkvmerge.exe"))
+                    {
+                        process.StartInfo.FileName = "./Plugins/MKVToolNix/mkvmerge.exe";
+                    }
+                    else if (File.Exists("./Plugins/Plugins/MKVToolNix/mkvmerge.exe"))
+                    {
+                        process.StartInfo.FileName = "./Plugins/Plugins/MKVToolNix/mkvmerge.exe";
+                    }
+                    else
+                    {
+                        process.StartInfo.FileName = "mkvmerge.exe";
+                    }
+                }
+                else
+                {
+                    process.StartInfo.FileName = "mkvmerge";
+                }
+
+                process.Start();
+                process.BeginErrorReadLine();
+                process.BeginOutputReadLine();
+                process.Exited += (sender, e) =>
+                {
+                    Process P = (Process)sender;
+                    Log.Info(nameof(FixDurationWithMkvToolnixAsync), "MKVToolNix 修复任务完成:" + P.StartInfo.Arguments);
+                };
+                await process.WaitForExitAsync();
+                process = null;
+            }
+            catch (Exception e)
+            {
+                Log.Error(nameof(FixDurationWithMkvToolnixAsync), $"MKVToolNix修复任务出现未知错误:{e}", e, true);
+                using (StreamWriter fileStream = new StreamWriter(before + "_MKVToolNix_fix日志.log", true, Encoding.UTF8))
+                {
+                    foreach (var item in LogText)
+                    {
+                        fileStream.WriteLine(item);
+                    }
+                }
+                LogTextAsString = string.Join(Environment.NewLine, LogText);
+                Log.Info(nameof(FixDurationWithMkvToolnixAsync), $"MKVToolNix修复任务完成:输出fix_log文件[{before + "_MKVToolNix_fix日志.log"}]");
+               
+            }
+			LogText = null;
+		}
     }
 }

--- a/Desktop/Desktop.csproj
+++ b/Desktop/Desktop.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="plugins\MKVToolnix\" />
     <Folder Include="Resource\" />
   </ItemGroup>
 

--- a/Desktop/Models/ToolsPageModels.cs
+++ b/Desktop/Models/ToolsPageModels.cs
@@ -10,6 +10,7 @@ namespace Desktop.Models
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
         public string FixMessage { set; get; } = string.Empty;
-    }
+        public string FixTimeMessage { set; get; } = string.Empty;
+	}
 }
 

--- a/Desktop/Views/Pages/AboutPage.xaml
+++ b/Desktop/Views/Pages/AboutPage.xaml
@@ -34,7 +34,7 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <ui:TextBlock Grid.Row="0" Grid.Column="0" FontSize="16" FontTypography="Body" Text="DDTV" />
-                    <ui:TextBlock Grid.Row="1" Grid.Column="0" FontSize="12" Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}" Text="Copyright © 2019-2024 Open Source Community." />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0" FontSize="12" Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}" Text="Copyright © 2019-2025 Open Source Community." />
                 </Grid>
             </ui:CardExpander.Header>
             <Grid>

--- a/Desktop/Views/Pages/ToolsPage.xaml
+++ b/Desktop/Views/Pages/ToolsPage.xaml
@@ -33,7 +33,7 @@
          
               
                 <!--登录态相关设置-->
-                <ui:CardExpander Grid.Row="2" Icon="{ui:SymbolIcon ArrowSyncCheckmark20}">
+                <ui:CardExpander Grid.Row="0" Icon="{ui:SymbolIcon ArrowSyncCheckmark20}">
                     <ui:CardExpander.Header>
                         <Grid>
                             <Grid.RowDefinitions>
@@ -62,7 +62,33 @@
                     </StackPanel>
 
                 </ui:CardExpander>
-               
+                <ui:CardExpander Grid.Row="1" Icon="{ui:SymbolIcon Wrench20}">
+                    <ui:CardExpander.Header>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <ui:TextBlock Grid.Row="0" Grid.Column="0" FontSize="16" FontTypography="Body" Text="MKVToolNix修复" />
+                            <ui:TextBlock Grid.Row="1" Grid.Column="0" FontSize="12" Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}" Text="自动转码的时间与实际时间不符可以使用该功能进行修复" />
+                        </Grid>
+                    </ui:CardExpander.Header>
+                    <StackPanel Margin="24,0,24,0">
+                        <Grid VerticalAlignment="Center"  HorizontalAlignment="Left">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="auto" />
+                                <ColumnDefinition Width="auto" />
+                            </Grid.ColumnDefinitions>
+                            <ui:Button Grid.Column="0" Content="选择源文件！非转码后带有_fix后缀的文件"  VerticalAlignment="Center" Click="MKVToolnix_Repair_Button_Click"/>
+                            <ui:TextBlock Margin="24,0,0,0"  Name="FixtimeTextBlock" Grid.Column="1" FontSize="16"  VerticalAlignment="Center" FontTypography="Body" Text="选择文件后，修复将在后台进行，请稍候查看原路径'_fix'后缀文件即可"/>
+                        </Grid>
+                    </StackPanel>
+                </ui:CardExpander>
+
             </Grid>
 
         </StackPanel>

--- a/Desktop/Views/Pages/ToolsPage.xaml.cs
+++ b/Desktop/Views/Pages/ToolsPage.xaml.cs
@@ -55,4 +55,41 @@ public partial class ToolsPage
 
 
     }
+
+	//新按钮对应的事件（MKVToolnix修复）
+	private void MKVToolnix_Repair_Button_Click(object sender, RoutedEventArgs e)
+	{
+		OpenFileDialog openFileDialog = new OpenFileDialog();
+		openFileDialog.Filter = "需要修复时长的视频文件(*.flv,*.mp4)|*.flv;*.mp4";
+		if (openFileDialog.ShowDialog() == DialogResult.OK)
+		{
+			string result = openFileDialog.FileName;
+			Task.Run(async () =>
+			{
+				Transcode transcode = new Transcode();
+				try
+				{
+					toolsPageModels.FixTimeMessage = "正在用MKVToolNix修复文件";
+					Dispatcher.Invoke(() => FixtimeTextBlock.Text = toolsPageModels.FixTimeMessage);
+					toolsPageModels.OnPropertyChanged("FixTimeMessage");
+					string before = result;
+					string after = System.IO.Path.Combine(
+						System.IO.Path.GetDirectoryName(result)!,
+						System.IO.Path.GetFileNameWithoutExtension(result) + "_fix.mkv"
+					);
+					await transcode.FixDurationWithMkvToolnixAsync(before, after);
+					toolsPageModels.FixTimeMessage = "MKVToolNix修复完成";
+					Dispatcher.Invoke(() => FixtimeTextBlock.Text = toolsPageModels.FixTimeMessage);
+					toolsPageModels.OnPropertyChanged("FixTimeMessage");
+				}
+				catch (Exception ex)
+				{
+					toolsPageModels.FixTimeMessage = "MKVToolNix修复发生错误，详情查看日志";
+					Dispatcher.Invoke(() => FixtimeTextBlock.Text = toolsPageModels.FixTimeMessage);
+					toolsPageModels.OnPropertyChanged("FixTimeMessage");
+					Log.Error(nameof(MKVToolnix_Repair_Button_Click), $"MKVToolNix修复时出现意外错误，文件:{result}");
+				}
+			});
+		}
+	}
 }


### PR DESCRIPTION
# 描述
如题
AboutPage.xaml修改2024到2025
Transcode.cs增加   **FixDurationWithMkvToolnixAsync**   使用 MKVToolNix 修复 MKV 文件时长的异步函数
ToolsPageModels.cs增加   **FixTimeMessage**    存消息用的
ToolsPage.xaml 增加新按钮和下拉菜单
### **mkvmerge需要在action里面添加，不会改（**

# 文档的特性/变更总结
加功能了，文档也可以加了吧（

# 怎么测试的？

github action构建DDTV_5_Test ac了，手动在plugins文件夹中的MKVToolNix文件夹中添加mkvmerge.exe后本地确认输出mkv是正常的，目前缺少可以验证修复码流的源文件，但是用正常文件修复是正常的



# 核查清单:

_请剔除无关项._

- [x] 我的代码符合项目的样式规范。
- [x] 我对我的代码进行了自我检查。
- [x] 我已对代码进行注释，特别是晦涩难懂的部分。
- [x] 我写的代码没蹦出新的警告。
