### PR TITLE
统一了右键菜单和右上角叉号的退出方法，把分隔线删了，对齐了defaultpage中第二行的容器(吧)

### DIFF
--- a/Desktop/MainWindow.xaml
+++ b/Desktop/MainWindow.xaml
@@ -28,7 +28,16 @@
             </Grid.RowDefinitions>
 
             <ui:NavigationView x:Name="RootNavigation" Grid.Row="1" IsBackButtonVisible="Collapsed" OpenPaneLength="180" >
-
+                <ui:NavigationView.Resources>
+                    <!--感谢群友开源一直寻思是separator的问题（误）-->
+                    <Style TargetType="Border">
+                        <Style.Triggers>
+                            <Trigger Property="Height" Value="1">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </ui:NavigationView.Resources>
                 <ui:NavigationView.Header>
                     <ui:BreadcrumbBar Margin="42,32,0,0" FontSize="28" FontWeight="DemiBold" />
                 </ui:NavigationView.Header>

--- a/Desktop/NotifyIcon.cs
+++ b/Desktop/NotifyIcon.cs
@@ -88,28 +88,18 @@ namespace Desktop
 		}
 
 		/// <summary>
-		/// 右键退出菜单项点击事件，弹出确认对话框并处理退出逻辑。
+		/// 右键退出菜单项点击事件，调用主窗口的退出确认逻辑。
 		/// </summary>
 		private async void RightClickExit(object sender, RoutedEventArgs e)
 		{
-			var messageBox = new Wpf.Ui.Controls.MessageBox
+			MainWindow mainWindow = Application.Current.MainWindow as MainWindow;
+			if (mainWindow != null)
 			{
-				Title = "关闭确认",
-				Content = "确认要关闭DDTV吗？\r\n关闭后所有录制任务以及播放窗口均会结束。",
-				PrimaryButtonText = "是",
-				SecondaryButtonText = "否",
-				IsCloseButtonEnabled = false 
-				/*注意：IsCloseButtonEnabled 属性仅在 Wpf.Ui 4.0.3里可用，
-				如果确定要更新的话可以把mainwindow里面的 FluentWindow_Closing也给换成这个退出，统一风格（
-				如果不合并把pr关掉我改回去*/
-			};
-
-			var result = await messageBox.ShowDialogAsync();
-
-			if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)
-			{
-				Desktop.Views.Pages.DataPage.Timer_DataPage?.Dispose();
-				Environment.Exit(-114514);
+				bool shouldExit = await mainWindow.ShowExitConfirmationAsync();
+				if (shouldExit)
+				{
+					Environment.Exit(-114514);
+				}
 			}
 		}
 

--- a/Desktop/Views/Pages/DefaultPage.xaml
+++ b/Desktop/Views/Pages/DefaultPage.xaml
@@ -49,7 +49,7 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <Border Grid.Column="0" Margin="3" CornerRadius="10" BorderBrush="#CCCCCC" BorderThickness="0,0,0,0"  Background="#343434">
+                <Border Grid.Column="0" Margin="0" CornerRadius="10" BorderBrush="#CCCCCC" BorderThickness="0,0,0,0"  Background="#343434">
                     <Grid Margin="25,0,25,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="auto" />
@@ -59,7 +59,7 @@
                         <TextBlock Grid.Column="1" Text="{Binding LiveCount,Mode=OneWay}" FontSize="50" HorizontalAlignment="Center" VerticalAlignment="Center"></TextBlock>
                     </Grid>
                 </Border>
-                <Border Grid.Column="1" Margin="3" CornerRadius="10" BorderBrush="#CCCCCC" BorderThickness="0,0,0,0"  Background="#343434">
+                <Border Grid.Column="1" Margin="3,0,0,0" CornerRadius="10" BorderBrush="#CCCCCC" BorderThickness="0,0,0,0"  Background="#343434">
                     <Grid Margin="25,0,25,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="auto" />


### PR DESCRIPTION
# 描述

统一了右键菜单和右上角叉号的退出方法，把分隔线删了，对齐了defaultpage中第二行的容器(吧)
如图
<img width="915" height="309" alt="image" src="https://github.com/user-attachments/assets/0fca5cf7-2b6e-4538-894f-5a50324ddbb6" />
<img width="595" height="324" alt="image" src="https://github.com/user-attachments/assets/15441adb-6bee-4852-9d5d-e8b9392722f4" />



# 核查清单:

_请剔除无关项._

- [x] 我的代码符合项目的样式规范。
- [x] 我对我的代码进行了自我检查。
- [x] 我已对代码进行注释，特别是晦涩难懂的部分。
- [x] 我写的代码没蹦出新的警告。
